### PR TITLE
メッセージ送信機能修正

### DIFF
--- a/app/assets/javascripts/message.js
+++ b/app/assets/javascripts/message.js
@@ -63,6 +63,7 @@ $(function(){
     .fail(function() {
       alert("メッセージ送信に失敗しました");
     });
+    return false;
   });
 
   var reloadMessages = function() {


### PR DESCRIPTION
# What
メッセージ送信機能にて、空の状態でSENDボタンを押したときにアラートが表示された後、
再度SENDボタンを押そうとしてもボタンが押せず、画面をリロードしなくてはならなかった部分を修正した。

# Why
非同期通信機能が未完成となってしまっていたため。